### PR TITLE
[MonacoInstance] add zoom support

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="description" content="CLP Log Viewer">
     <meta name="keywords" content="clp debug debugging large log logs s3 scanner viewer vscode">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 </head>
 <body>
     <div id="app"></div>


### PR DESCRIPTION
# References
Zhihao reported that zoom in/out support was missing on mobile devices. 

# Description
1. [Mobile] Prevent auto zoom-in when clicking on text area in editor. 
2. [Mobile: Android only] Register touch event handlers to detect zoom events and change zoom level of whole document when needed.
3. [PC / macOS] Enable `Ctrl + Scroll` zoom support via [Monaco Editor's mouseWheelZoom constructor option](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IEditorConstructionOptions.html#mouseWheelZoom)

# Validation performed
## [Android]
Device: Samsung Z Flip 5
Display size: 6.7‑inch (diagonal)
Resolution: 2640 x 1080
User Agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Mobile Safari/537.36 EdgA/117.0.2045.65
1. Loaded log archive file in LogViewer. 
2. With 2 fingers, pinched in on editor and observed contents zoomed in. Fonts and icons became bigger, less contents became visible, and no apparent layout issue was observed. 
3. With 2 fingers, pinched out on editor and observed contents zoomed out. Fonts and icons became smaller, more contents became visible, and no apparent layout issue was observed. 

## [iOS] 
Device: iPhone 13 Pro Max
Display size: 6.7‑inch (diagonal)
Resolution: 2778 x 1284
User Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1
1. Loaded log archive file in LogViewer. 
2. Pinched in and out and observed no content was zoomed in / out. 
3. Clicked "aA" button in URL bar:
   3a. Clicked larger "A" button and observed contents zoomed in. Fonts and icons became bigger, less contents became visible, and no apparent layout issue was observed. 
   3b. Clicked smaller "A" button and observed contents zoomed out. Fonts and icons became smaller, more contents became visible, and no apparent layout issue was observed. 

## [PC]
User Agent: Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1 Edg/119.0.0.0
1. Loaded log archive file in LogViewer. 
2. Held down `Ctrl` key and scrolled mouse wheel up. Observed contents zoomed in. Fonts became larget in code editor, less contents became visible, and no apparent layout issue was observed. 
3. Held down `Ctrl` key and scrolled mouse wheel down. Observed contents zoomed out. Fonts became smaller in code editor, more contents became visible, and no apparent layout issue was observed. 