### PR TITLE
add Download Uncompressed Logs functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "compression-webpack-plugin": "^10.0.0",
     "crypto-browserify": "^3.12.0",
     "css-unicode-loader": "^1.0.3",
+    "dexie": "^3.2.4",
     "html-webpack-plugin": "^5.5.0",
     "monaco-editor-webpack-plugin": "^7.0.1",
     "path": "^0.12.7",

--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -182,6 +182,16 @@ export function Viewer ({fileInfo, prettifyLog, logEventNumber, timestamp}) {
                     desiredLogEventIdx: args.logEventIdx,
                 });
                 break;
+            case STATE_CHANGE_TYPE.startDownload:
+                clpWorker.current.postMessage({
+                    code: CLP_WORKER_PROTOCOL.START_DOWNLOAD,
+                });
+                break;
+            case STATE_CHANGE_TYPE.stopDownload:
+                clpWorker.current.postMessage({
+                    code: CLP_WORKER_PROTOCOL.STOP_DOWNLOAD,
+                });
+                break;
             default:
                 break;
         }

--- a/src/Viewer/components/MenuBar/DOWNLOAD_WORKER_ACTION.js
+++ b/src/Viewer/components/MenuBar/DOWNLOAD_WORKER_ACTION.js
@@ -1,0 +1,10 @@
+let DOWNLOAD_WORKER_ACTION = {
+    initialize: "initialize",
+    pageData: "pageData",
+    progress: "progress",
+    clearDatabase: "clearDatabase",
+    error: "error",
+};
+DOWNLOAD_WORKER_ACTION = Object.freeze(DOWNLOAD_WORKER_ACTION);
+
+export default DOWNLOAD_WORKER_ACTION;

--- a/src/Viewer/components/MenuBar/DownloadHelper.js
+++ b/src/Viewer/components/MenuBar/DownloadHelper.js
@@ -1,0 +1,51 @@
+const downloadBlob = (blob, databaseName) => {
+    const blobUrl = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = blobUrl;
+    link.download = databaseName.split(".")[0] + ".log";
+    document.body.appendChild(link);
+    link.dispatchEvent(
+        new MouseEvent("click", {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+        })
+    );
+    document.body.removeChild(link);
+};
+
+const BlobAppender = function () {
+    let blob = new Blob([], {type: "text"});
+    this.append = function (src) {
+        blob = new Blob([blob, src], {type: "text"});
+    };
+    this.getBlob = function () {
+        return blob;
+    };
+};
+
+const downloadCompressedFile = () => {
+    const link = document.createElement("a");
+
+    // this opens the link in a new tab,
+    //  which avoids interruption of uncompressed logs download
+    link.target = "_blank";
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const filePath = urlParams.get("filePath");
+    try {
+        // this URL constructor should only succeed if "filePath"
+        //  has a "protocol" scheme like "http:"
+        new URL(filePath);
+        link.href = filePath;
+    } catch (e) {
+        console.log(`Unable to construct URL object from "${filePath}": ${e}. 
+        Assuming the file is from current origin. `);
+        link.href = window.location.origin + "/" + filePath;
+    }
+
+    console.log(link);
+    link.click();
+};
+
+export {BlobAppender, downloadBlob, downloadCompressedFile};

--- a/src/Viewer/components/MenuBar/downloadWorker.js
+++ b/src/Viewer/components/MenuBar/downloadWorker.js
@@ -1,0 +1,82 @@
+import Database from "../../services/Database";
+import DOWNLOAD_WORKER_ACTION from "./DOWNLOAD_WORKER_ACTION";
+
+let db = null;
+let totalCount;
+
+const getCount = () => {
+    return new Promise((resolve) => {
+        db.getNumberOfPages().then((count) => {
+            resolve(count);
+        }).catch(() => {
+            resolve(false);
+        });
+    });
+};
+
+const isDecodingDone = () => {
+    getCount().then((count) => {
+        if (count < totalCount) {
+            postMessage({
+                code: DOWNLOAD_WORKER_ACTION.progress,
+                progress: (count / totalCount) * 90,
+                done: false,
+            });
+            setTimeout(isDecodingDone, 100);
+        } else {
+            postMessage({
+                code: DOWNLOAD_WORKER_ACTION.progress,
+                progress: 90,
+                done: true,
+            });
+        }
+    });
+};
+
+onmessage = function (e) {
+    const msg = e.data;
+
+    switch (msg.code) {
+        case DOWNLOAD_WORKER_ACTION.initialize:
+            db = new Database(e.data.name);
+            totalCount = e.data.count;
+            isDecodingDone();
+            break;
+        case DOWNLOAD_WORKER_ACTION.pageData:
+            db.getPage(e.data.page).then((data) => {
+                if (undefined === data) {
+                    postMessage({
+                        code: DOWNLOAD_WORKER_ACTION.error,
+                        error: new Error("Page data was not loaded."),
+                    });
+                } else {
+                    postMessage({
+                        code: DOWNLOAD_WORKER_ACTION.pageData,
+                        data: data.data,
+                        page: e.data.page,
+                    });
+                }
+            }).catch((e) => {
+                postMessage({
+                    code: DOWNLOAD_WORKER_ACTION.error,
+                    error: new Error(e.reason),
+                });
+            });
+            break;
+        case DOWNLOAD_WORKER_ACTION.clearDatabase:
+            db.delete().then(() => {
+                postMessage({
+                    code: DOWNLOAD_WORKER_ACTION.clearDatabase,
+                    success: true,
+                });
+            }).catch(() => {
+                postMessage({
+                    code: DOWNLOAD_WORKER_ACTION.clearDatabase,
+                    success: false,
+                });
+            });
+            break;
+        default:
+            break;
+    }
+};

--- a/src/Viewer/services/ActionHandler.js
+++ b/src/Viewer/services/ActionHandler.js
@@ -153,6 +153,20 @@ class ActionHandler {
     }
 
     /**
+     * Start decoding pages to database for Uncompressed Log Download
+     */
+    startDecodingPagesToDatabase () {
+        this._logFile.startDecodingPagesToDatabase();
+    }
+
+    /**
+     * Stop decoding pages to database if Uncompressed Log Download is canceled
+     */
+    stopDecodingPagesToDatabase () {
+        this._logFile.stopDecodingPagesToDatabase();
+    }
+
+    /**
      * Send the newly decoded logs
      * @param {string} logs
      */

--- a/src/Viewer/services/CLP_WORKER_PROTOCOL.js
+++ b/src/Viewer/services/CLP_WORKER_PROTOCOL.js
@@ -1,16 +1,21 @@
+let enumClpWorkerProtocol = 0;
 let CLP_WORKER_PROTOCOL = {
-    LOADING_MESSAGES: 0,
-    LOAD_FILE: 1,
-    UPDATE_VERBOSITY: 2,
-    GET_LINE_FROM_EVENT: 3,
-    GET_EVENT_FROM_LINE: 4,
-    CHANGE_PAGE: 5,
-    LOAD_LOGS: 6,
-    REDRAW_PAGE: 7,
-    PRETTY_PRINT: 8,
-    UPDATE_STATE: 9,
-    UPDATE_FILE_INFO: 10,
-    ERROR: 11,
+    ERROR: enumClpWorkerProtocol++,
+    LOADING_MESSAGES: enumClpWorkerProtocol++,
+    LOAD_FILE: enumClpWorkerProtocol++,
+    UPDATE_VERBOSITY: enumClpWorkerProtocol++,
+    GET_LINE_FROM_EVENT: enumClpWorkerProtocol++,
+    GET_EVENT_FROM_LINE: enumClpWorkerProtocol++,
+    CHANGE_PAGE: enumClpWorkerProtocol++,
+    LOAD_LOGS: enumClpWorkerProtocol++,
+    REDRAW_PAGE: enumClpWorkerProtocol++,
+    PRETTY_PRINT: enumClpWorkerProtocol++,
+    UPDATE_STATE: enumClpWorkerProtocol++,
+    UPDATE_FILE_INFO: enumClpWorkerProtocol++,
+    START_DOWNLOAD: enumClpWorkerProtocol++,
+    STOP_DOWNLOAD: enumClpWorkerProtocol++,
+    REQ_BAIDU_PRESIGN_URL: enumClpWorkerProtocol++,
+    REC_BAIDU_PRESIGN_URL: enumClpWorkerProtocol++,
 };
 CLP_WORKER_PROTOCOL = Object.freeze(CLP_WORKER_PROTOCOL);
 

--- a/src/Viewer/services/Database.js
+++ b/src/Viewer/services/Database.js
@@ -1,0 +1,76 @@
+import Dexie from "dexie";
+
+/**
+ * Database class that wraps all indexedDB functions.
+ *
+ */
+class Database extends Dexie {
+    /**
+     * Initializes the database connection.
+     *
+     * @param {string} fileName Name of database.
+     */
+    constructor (fileName) {
+        super(fileName);
+        this.version(1).stores({
+            logData: "page",
+        });
+        this.logData = this.table("logData");
+    }
+
+    /**
+     * Reads page data from the database.
+     *
+     * @param {number} page
+     * @return {Promise<unknown>}
+     */
+    getPage (page) {
+        return new Promise(async (resolve, reject) => {
+            this.logData.get({page: page}).then((data) => {
+                resolve(data);
+            }).catch((reason) => {
+                console.log(reason);
+                reject(new Error(reason));
+            });
+        });
+    }
+
+    /**
+     * Adds page data to the database.
+     *
+     * @param {number} page
+     * @param {string} data
+     * @return {Promise<unknown>}
+     */
+    addPage (page, data) {
+        return new Promise(async (resolve, reject) => {
+            this.logData.add(
+                {
+                    page: page,
+                    data: data,
+                }
+            ).then(() => {
+                resolve(true);
+            }).catch((e) => {
+                reject(new Error(e));
+            });
+        });
+    }
+
+    /**
+     * Returns the number of decoded pages to the database.
+     *
+     * @return {Promise<unknown>}
+     */
+    getNumberOfPages () {
+        return new Promise(async (resolve, reject) => {
+            this.logData.count().then((number) => {
+                resolve(number);
+            }).catch((e) => {
+                reject(new Error(e));
+            });
+        });
+    }
+}
+
+export default Database;

--- a/src/Viewer/services/STATE_CHANGE_TYPE.js
+++ b/src/Viewer/services/STATE_CHANGE_TYPE.js
@@ -5,6 +5,8 @@ let STATE_CHANGE_TYPE = {
     pageSize: "pageSize",
     prettify: "prettify",
     verbosity: "verbosity",
+    startDownload: "startDownload",
+    stopDownload: "stopDownload",
 };
 STATE_CHANGE_TYPE = Object.freeze(STATE_CHANGE_TYPE);
 

--- a/src/Viewer/services/WorkerPool.js
+++ b/src/Viewer/services/WorkerPool.js
@@ -1,0 +1,90 @@
+/**
+ * Provides access to a pool of workers which can be used to execute tasks.
+ * Currently, only supports decode worker but will be extended for search.
+ */
+class WorkerPool {
+    /**
+     * Initialize the queue and an array to hold the workers.
+     */
+    constructor () {
+        this.taskQueue = [];
+        this._maxNumOfWorkers = 4;
+
+        this._workerPool = new Array(this._maxNumOfWorkers);
+        this._workerPool.fill(null);
+    }
+
+    /**
+     * Returns a worker if there is a free slot in the pool.
+     *
+     * @return {null|Worker}
+     */
+    getWorker () {
+        for (const index in this._workerPool) {
+            if (null === this._workerPool[index]) {
+                this._workerPool[index] = new Worker(
+                    new URL("./decoder/decodeWorker.js", import.meta.url)
+                );
+                return this._workerPool[index];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Frees a provided worker from the pool.
+     *
+     * @param {Worker} _worker
+     */
+    freeWorker (_worker) {
+        for (const index in this._workerPool) {
+            if (this._workerPool[index] === _worker) {
+                this._workerPool[index].terminate();
+                this._workerPool[index] = null;
+                break;
+            }
+        }
+    }
+
+    /**
+     * Process queue by assigning tasks to workers.
+     */
+    processQueue () {
+        if (this.taskQueue.length > 0) {
+            const worker = this.getWorker();
+            if (worker) {
+                const task = this.taskQueue.shift();
+                worker.postMessage(task, [task.inputStream]);
+                worker.onmessage = () => {
+                    this.freeWorker(worker);
+                    this.processQueue();
+                };
+                console.debug(`Started worker to load page ${task.page}`);
+            }
+        }
+    }
+
+    /**
+     * Added a task to the queue and process the queue.
+     * @param {object} task
+     */
+    assignTask (task) {
+        this.taskQueue.push(task);
+        this.processQueue();
+    }
+
+    /**
+     * Clear the worker pool.
+     */
+    clearPool () {
+        this.taskQueue = [];
+        for (const index in this._workerPool) {
+            if (this._workerPool[index]) {
+                this._workerPool[index].terminate();
+                this._workerPool[index] = null;
+            }
+        }
+    }
+}
+
+export default WorkerPool;

--- a/src/Viewer/services/clpWorker.js
+++ b/src/Viewer/services/clpWorker.js
@@ -78,6 +78,22 @@ onmessage = function (e) {
             }
             break;
 
+        case CLP_WORKER_PROTOCOL.START_DOWNLOAD:
+            try {
+                handler.startDecodingPagesToDatabase();
+            } catch (e) {
+                sendError(e);
+            }
+            break;
+
+        case CLP_WORKER_PROTOCOL.STOP_DOWNLOAD:
+            try {
+                handler.stopDecodingPagesToDatabase();
+            } catch (e) {
+                sendError(e);
+            }
+            break;
+
         default:
             break;
     }

--- a/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
+++ b/src/Viewer/services/decoder/FourByteClpIrStreamProtocolDecoder.js
@@ -10,7 +10,7 @@ class FourByteClpIrStreamProtocolDecoder {
         this.initializeStream(dataInputStream, tokenDecoder);
     }
 
-    validateVersion(version) {
+    validateVersion (version) {
         if (PROTOCOL.METADATA.VERSION_VALUE === version) {
             return true;
         }
@@ -146,8 +146,7 @@ class FourByteClpIrStreamProtocolDecoder {
 
     readAndValidateEncodingType (dataInputStream) {
         for (let i = 0; i < PROTOCOL.FOUR_BYTE_ENCODING_MAGIC_NUMBER.length; ++i) {
-            if (PROTOCOL.FOUR_BYTE_ENCODING_MAGIC_NUMBER[i] !== dataInputStream.readUnsignedByte())
-            {
+            if (PROTOCOL.FOUR_BYTE_ENCODING_MAGIC_NUMBER[i] !== dataInputStream.readUnsignedByte()) {
                 throw new Error("IR stream doesn't use the four-byte encoding.");
             }
         }

--- a/src/Viewer/services/decoder/decodeWorker.js
+++ b/src/Viewer/services/decoder/decodeWorker.js
@@ -1,0 +1,55 @@
+import Database from "../Database";
+import {DataInputStream, DataInputStreamEOFError} from "./DataInputStream";
+import FourByteClpIrStreamReader from "./FourByteClpIrStreamReader";
+import ResizableUint8Array from "./ResizableUint8Array";
+
+const decodePage = async (fileName, logEvents, inputStream, page) => {
+    const dataInputStream = new DataInputStream(inputStream);
+    const _outputResizableBuffer = new ResizableUint8Array(inputStream.byteLength);
+    const _irStreamReader = new FourByteClpIrStreamReader(dataInputStream, null);
+
+    const _logEventMetadata = [];
+    for (let i = 0; i < logEvents.length; i++) {
+        const decoder = _irStreamReader._streamProtocolDecoder;
+        decoder._setTimestamp(logEvents[i].prevTs);
+
+        try {
+            _irStreamReader.readAndDecodeLogEvent(
+                _outputResizableBuffer,
+                _logEventMetadata
+            );
+        } catch (error) {
+            // Ignore EOF errors since we should still be able
+            // to print the decoded messages
+            if (error instanceof DataInputStreamEOFError) {
+                // TODO Give visual indication that the stream is truncated
+                console.error("Stream truncated.");
+            } else {
+                console.log("random error");
+                throw error;
+            }
+        }
+    }
+
+    // Decode the text
+    const _textDecoder = new TextDecoder();
+    const logs = _textDecoder.decode(_outputResizableBuffer.getUint8Array());
+    const _logs = logs.trim();
+
+    const db = new Database(fileName);
+    db.addPage(page, _logs).then(() => {
+        console.debug(`Finished decoding page ${page} to database.`);
+        postMessage(true);
+    }).catch((e) => {
+        console.debug(e.toString());
+        postMessage(false);
+    });
+};
+
+onmessage = (e) => {
+    const fileName = e.data.fileName;
+    const logEvents = e.data.logEvents;
+    const inputStream = e.data.inputStream;
+    const page = e.data.page;
+    decodePage(fileName, logEvents, inputStream, page);
+};

--- a/src/Viewer/services/decoder/utils.js
+++ b/src/Viewer/services/decoder/utils.js
@@ -1,3 +1,17 @@
+/**
+ * Merges two array buffers together.
+ *
+ * @param {ArrayBuffer} buffer1
+ * @param {ArrayBuffer} buffer2
+ * @return {ArrayBuffer} Merged array buffer.
+ */
+function combineArrayBuffers (buffer1, buffer2) {
+    const bufferData = new Uint8Array(buffer1.byteLength + buffer2.byteLength);
+    bufferData.set(new Uint8Array(buffer1), 0);
+    bufferData.set(new Uint8Array(buffer2), buffer1.byteLength);
+    return bufferData.buffer;
+}
+
 function javaIntegerDivide (top, bottom) {
     const integerQuotient = Math.trunc(top / bottom);
     // In Java -5 / 10 = 0 whereas in JavaScript, Math.trunc(-5 / 10) = -0, so
@@ -6,8 +20,7 @@ function javaIntegerDivide (top, bottom) {
 }
 
 function uint8ArrayContains (haystackArray, haystackArrayBeginOffset, needleArray,
-                             needleArrayBeginOffset)
-{
+    needleArrayBeginOffset) {
     const needleLength = needleArray.length - needleArrayBeginOffset;
     const haystackLength = haystackArray.length - haystackArrayBeginOffset;
     if (needleLength > haystackLength) {
@@ -16,8 +29,7 @@ function uint8ArrayContains (haystackArray, haystackArrayBeginOffset, needleArra
 
     for (let i = 0; i < needleLength; ++i) {
         if (haystackArray[haystackArrayBeginOffset + i] !==
-            needleArray[needleArrayBeginOffset + i])
-        {
+            needleArray[needleArrayBeginOffset + i]) {
             return false;
         }
     }
@@ -79,8 +91,7 @@ function formatSizeInBytes (value, useSiUnits = true, numFractionalDigits = 1) {
     // return "1000.0 kB", but it should return "1.0 MB".
     const multiplier = 10 ** numFractionalDigits;
     for (unitIdx = 0; Math.round(Math.abs(value) * multiplier) / multiplier >= divisor
-        && unitIdx < units.length; ++unitIdx)
-    {
+        && unitIdx < units.length; ++unitIdx) {
         value /= divisor;
     }
 
@@ -107,5 +118,5 @@ function isNumeric (value) {
     return (typeof value === "number");
 }
 
-export {countByteOccurrencesInUtf8Uint8Array, formatSizeInBytes,
+export {combineArrayBuffers, countByteOccurrencesInUtf8Uint8Array, formatSizeInBytes,
     isBoolean, isNumeric, javaIntegerDivide, uint8ArrayContains};


### PR DESCRIPTION
# References
Customer reported they want this "Download Uncompressed Log" feature. 

# Description
Changes were ported from private repo with below fixes (@jackluo923 we might want to back port these fixes into the private repo):
1. During `window.onbeforeunload`, avoid stopping download worker if it is never created (user never requested Uncompressed Download). 
2. For Compressed Log Download, avoid appending origin name if filePath is already a complete URL with protocol name like `http:` or `https:`.
3. For Compressed Log Download, open the link in a new tab to avoid interruption of Uncompressed Log Download. 

# Validation performed
1. Load a compressed log archive.
2. Click Download button in the menu bar. 
3. Start Uncompressed Log Download. 
4. Before the Uncompressed Log finishes loading, trigger a Compressed Log download and observe the Compressed Log archive successfully downloaded without interrupting the Uncompressed Log loading. 
5. Wait till the Uncompressed Log loading finishes and observe the Uncompressed Log file to be automatically downloaded. 
6. In the Viewer, change the log event page size to 1000000 so that all log events can be loaded in one page. Copy the page content, compare against the Uncompressed Log file and observe no discrepancy. 

# TODO
1. All Uncompressed Logs are downloaded with name "search_result" because the name is hardcoded in https://github.com/LinZhihao-723/yscope-log-viewer/blob/c3d92bc5e3743a9bb6b32736afe82d083b1fc629/src/Viewer/services/GetFile.js#L48

